### PR TITLE
for flexible format support

### DIFF
--- a/lib/JSV/Context.pm
+++ b/lib/JSV/Context.pm
@@ -12,7 +12,8 @@ use Class::Accessor::Lite (
         throw_error
         throw_immediate
         enable_history
-        format_support
+        enable_format
+        formats
         history
         json
     /],

--- a/lib/JSV/Keyword/Draft4/Format.pm
+++ b/lib/JSV/Keyword/Draft4/Format.pm
@@ -16,11 +16,11 @@ sub keyword_priority() { 10; }
 
 sub validate {
     my ($class, $context, $schema, $instance) = @_;
-    return unless $context->format_support || keys %{ $context->format_support } == 0;
+    return unless $context->enable_format;
 
     my $format = $class->keyword_value($schema);
 
-    if ( my $format_validator = $context->format_support->{$format} ) {
+    if ( my $format_validator = $context->formats->{$format} ) {
         unless ( $format_validator->($instance) ) {
             $context->log_error("The instance does not pass '$format' format check");
         }

--- a/lib/JSV/Validator.pm
+++ b/lib/JSV/Validator.pm
@@ -9,10 +9,11 @@ use Class::Accessor::Lite (
         reference
         environment
         environment_keywords
+        enable_format
         enable_history
         throw_error
         throw_immediate
-        format_support
+        formats
     /]
 );
 use Clone qw(clone);
@@ -61,8 +62,9 @@ sub new {
     %args = (
         environment     => 'draft4',
         enable_history  => 0,
+        enable_format   => 1,
         reference       => JSV::Reference->new,
-        format_support  => +{
+        formats         => +{
             'date-time' => sub {
                 # RFC3339
                 ($_[0] =~ /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})/);
@@ -113,17 +115,18 @@ sub validate {
             INSTANCE_TYPE_ARRAY()   => $self->instance_type_keywords(INSTANCE_TYPE_ARRAY),
             INSTANCE_TYPE_OBJECT()  => $self->instance_type_keywords(INSTANCE_TYPE_OBJECT),
         },
-        reference       => $self->reference,
-        environment     => $self->environment,
-        original_schema => $schema,
-        throw_error     => $self->throw_error,
-        throw_immediate => $self->throw_immediate,
-        enable_history  => $self->enable_history,
-        format_support  => $self->format_support,
-        history         => [],
-        errors          => [],
-        current_pointer => "",
-        json            => JSON->new->allow_nonref,
+        reference        => $self->reference,
+        environment      => $self->environment,
+        original_schema  => $schema,
+        throw_error      => $self->throw_error,
+        throw_immediate  => $self->throw_immediate,
+        enable_history   => $self->enable_history,
+        enable_format    => $self->enable_format,
+        formats          => $self->formats,
+        history          => [],
+        errors           => [],
+        current_pointer  => "",
+        json             => JSON->new->allow_nonref,
     );
 
     return $context->validate($schema, $instance);
@@ -144,7 +147,7 @@ sub unregister_schema {
 
 sub register_format {
     my ($self, $format, $format_validator) = @_;
-    shift->format_support->{$format} = $format_validator;
+    shift->formats->{$format} = $format_validator;
 }
 
 1;

--- a/t/01_validator.t
+++ b/t/01_validator.t
@@ -10,15 +10,15 @@ subtest "register_format" => sub {
         $validator->register_format("hoge" => sub {
             $_[0] eq "hoge";
         });
-        ok $validator->format_support->{"hoge"};
+        ok $validator->formats->{"hoge"};
     };
     subtest "register from zero" => sub {
-        my $validator = JSV::Validator->new(format_support => +{});
+        my $validator = JSV::Validator->new(formats => +{});
         $validator->register_format("hoge" => sub {
             $_[0] eq "hoge";
         });
-        ok $validator->format_support->{"hoge"};
-        is keys %{ $validator->format_support }, 1;
+        ok $validator->formats->{"hoge"};
+        is keys %{ $validator->formats }, 1;
     };
 };
 


### PR DESCRIPTION
```
# disable format, default = enable
JSV::Validator->new(enable_format => 0);
```

```
# replace formats, entirely
JSV::Validator->new(
    formats => +{
        original_format => sub {
            my $instance = shift;
            return $instance eq "omoro-";
        }
    }
);
```

```
# add new format or override existing format
$jsv_instance->register_format("original_format" => sub {
    my $instance = shift;
});
```

みたいな感じで。
