### PR TITLE
perldoc JSV.pm points towards JSV::Validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ JSV - JSON Schema implementation of Perl
 
 # DESCRIPTION
 
-JSV is ...
+See e.g. [JSV::Validator](https://metacpan.org/pod/JSV::Validator)
 
 # LICENSE
 

--- a/lib/JSV.pm
+++ b/lib/JSV.pm
@@ -21,7 +21,7 @@ JSV - JSON Schema implementation of Perl
 
 =head1 DESCRIPTION
 
-JSV is ...
+See e.g. L<JSV::Validator>
 
 =head1 LICENSE
 


### PR DESCRIPTION
README.md was updated accordingly with:

perl -MPod::Markdown -e 'Pod::Markdown->new->filter(@ARGV)' lib/JSV.pm > README.md

Because it looked like that is how it was created in the first place.

The purpose was just point in the right direction. I went looking in
the t/* and the code before I discovered the perldoc in
JSV::Validator, and a pointer would've saved me some time.

I can see that the README.md link

    [JSV::Validator](https://metacpan.org/pod/JSV::Validator)

is a little problematic in that it points to metacpan and not
./lib/JSV/Validator.pm, but that is how Pod::Markdown converts a
L<JSV::Validator> link, and I believe that L<JSV::Validator> is the
correct link in the perldoc. You decide.