### PR TITLE
let get_schema die when unregistered uri provided

### DIFF
--- a/lib/JSV/Reference.pm
+++ b/lib/JSV/Reference.pm
@@ -40,9 +40,10 @@ sub resolve {
         $self->resolve($ref_obj, $opts);
     }
 
+    %$ref = %$ref_obj;
+
     ### TODO: Does this weaken have means?
     weaken($ref_obj);
-    %$ref = %$ref_obj;
 
     $ref->{id} = $ref_uri->as_string;
 }
@@ -55,6 +56,9 @@ sub get_schema {
 
     my ($normalized_uri, $fragment) = $self->normalize_uri($uri);
     my $schema = $self->{registered_schema_map}{$normalized_uri} || $opts->{root};
+    unless (ref $schema eq 'HASH') {
+        die sprintf("cannot resolve reference: uri = %s", $uri);
+    }
 
     if (exists $schema->{'$ref'} && $schema->{'$ref'} eq $normalized_uri) {
         die sprintf("cannot resolve reference: uri = %s", $uri);

--- a/t/02_reference.t
+++ b/t/02_reference.t
@@ -22,11 +22,10 @@ subtest "cannot resolve reference" => sub {
     subtest 'uri not found' => sub {
         local $@;
         my $ref = { '$ref' => 'http://notfound.schema.com/schema' };
-        eval {
+        throws_ok {
             $reference->resolve($ref, +{});
-        };
+        } qr/^cannot resolve reference/;
         note $@;
-        ok $@;
     };
 
     subtest 'uri found' => sub {
@@ -42,11 +41,10 @@ subtest "cannot resolve reference" => sub {
     subtest 'fragment not found' => sub {
         local $@;
         my $ref = { '$ref' => 'http://example.schema.com/schema#/bad_fragment' };
-        eval {
+        throws_ok {
             $reference->resolve($ref, +{});
-        };
+        } qr/^cannot resolve reference fragment/;
         note $@;
-        ok $@;
     };
 
     subtest 'fragment found' => sub {


### PR DESCRIPTION
### ビフォーアフター
  * 現状：get_schemaの第一引数に、registerされていないuriを与えると、空のhashが返ってくる
  * 修正後：`cannot resolve reference`でdieするようになる

### 原因
  * `if (exists $schema->{'$ref'} && $schema->{'$ref'} eq $normalized_uri) {`
  * $schemaがundefの場合でも、この行でhashrefとしてアクセスされた結果、空のhashrefになってしまう
  * 結果として最後のrefチェックを通ってしまう

### 対応
  * $schemaを取得した直後にもチェック追加

### 補足
  * weakenの意味よくわかんなかったんすけど、なんかこのせいでundefになったりとかしてtestを騙しちゃったりしてたんで、とりあえず順序だけ変えました

