### PR TITLE
Feature/perl db

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl extension JSV
 
 {{$NEXT}}
 
+    - Test::JSV::Suite passes each test case to callback
+
 0.06 2015-08-25T15:20:55Z
 
     - Support relative URI for JSON reference

--- a/lib/Test/JSV/Suite.pm
+++ b/lib/Test/JSV/Suite.pm
@@ -58,7 +58,7 @@ sub run_test_case {
     my ($desc, $data, $expect) = @$test_case{qw/description data valid/};
 
     is(
-        $self->{cb}->($schema, $data, $expect),
+        $self->{cb}->($schema, $data, $expect, $test_case),
         $expect ? 1 : 0,
         $desc,
     );


### PR DESCRIPTION
Added feature that Test::JSV::Suite passes each test case to callback as forth argument.
Because callback can handle testing by test case. For example,

```perl
my $validator = JSV::Validator->new;

Test::JSV::Suite->run(
  base_dir => "/path/to/dir",
  suite       => "/path/to/suite.json",
  cb           => sub {
    my ($schema, $instance, $expect, $test_case) = @_;

    ## for backward compatibility, testing forth argument
    if (defined $test_case && $test_case->{db}) {
      $DB::single = 1;
    }

    return $validator->validate($schema, $instance);
  }
);
```