### PR TITLE
Use canonical option on evaluate unique items

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -25,5 +25,6 @@ requires 'URI::Split';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';
+    requires 'Test::Requires';
 };
 

--- a/lib/JSV/Keyword/Draft4/UniqueItems.pm
+++ b/lib/JSV/Keyword/Draft4/UniqueItems.pm
@@ -18,6 +18,7 @@ sub validate {
     my $keyword_value = $class->keyword_value($schema);
 
     if ($keyword_value) {
+        $context->json->canonical(1);
         my @unique = uniq map {
             $context->json->encode($_)
         } @$instance;
@@ -25,6 +26,7 @@ sub validate {
         if (scalar @unique != scalar @$instance) {
             $context->log_error("The instance array is not unique");
         }
+        $context->json->canonical(0);
     }
 }
 

--- a/t/issues/00041_canonical_pp.t
+++ b/t/issues/00041_canonical_pp.t
@@ -15,9 +15,6 @@ my $schema = {
 };
 
 subtest 'check cannonical on PP' => sub {
-    my $is_pp = JSON->is_pp;
-    ok $is_pp, 'backend is pp';
-
     my $compare = { map { $_ => 1 } @KEYS };
     my $target  = { map { $_ => 1 } reverse @KEYS };
     is ($v->validate($schema, [$compare, $target]), 0, 'validated as uniqueItems');

--- a/t/issues/00041_canonical_pp.t
+++ b/t/issues/00041_canonical_pp.t
@@ -1,0 +1,28 @@
+BEGIN { $ENV{PERL_JSON_BACKEND} = 'JSON::PP' };
+
+use strict;
+use warnings;
+use Test::More;
+use JSV::Validator;
+use Test::Requires qw(JSON::PP);
+use JSON qw//;
+
+my @KEYS   = 'a'..'e';
+my $v      = JSV::Validator->new(environment => 'draft4');
+my $schema = {
+    type => 'array',
+    uniqueItems => 1
+};
+
+subtest 'check cannonical on PP' => sub {
+    my $is_pp = JSON->is_pp;
+    ok $is_pp, 'backend is pp';
+
+    my $compare = { map { $_ => 1 } @KEYS };
+    my $target  = { map { $_ => 1 } reverse keys %$compare };
+    is ($v->validate($schema, [$compare, $target]), 0, 'validated as uniqueItems');
+};
+
+done_testing;
+
+1;

--- a/t/issues/00041_canonical_pp.t
+++ b/t/issues/00041_canonical_pp.t
@@ -3,11 +3,11 @@ BEGIN { $ENV{PERL_JSON_BACKEND} = 'JSON::PP' };
 use strict;
 use warnings;
 use Test::More;
-use JSV::Validator;
 use Test::Requires qw(JSON::PP);
+use JSV::Validator;
 use JSON qw//;
 
-my @KEYS   = 'a'..'e';
+my @KEYS   = ('a'..'e');
 my $v      = JSV::Validator->new(environment => 'draft4');
 my $schema = {
     type => 'array',
@@ -19,7 +19,7 @@ subtest 'check cannonical on PP' => sub {
     ok $is_pp, 'backend is pp';
 
     my $compare = { map { $_ => 1 } @KEYS };
-    my $target  = { map { $_ => 1 } reverse keys %$compare };
+    my $target  = { map { $_ => 1 } reverse @KEYS };
     is ($v->validate($schema, [$compare, $target]), 0, 'validated as uniqueItems');
 };
 

--- a/t/issues/00041_canonical_xs.t
+++ b/t/issues/00041_canonical_xs.t
@@ -7,7 +7,7 @@ use Test::Requires qw(JSON::XS);
 use JSV::Validator;
 use JSON qw//;
 
-my @KEYS   = 'a'..'e';
+my @KEYS   = ('a'..'e');
 my $v      = JSV::Validator->new(environment => 'draft4');
 my $schema = {
     type => 'array',
@@ -19,7 +19,7 @@ subtest 'check cannonical on XS' => sub {
     ok $is_xs, 'backend is xs';
 
     my $compare = { map { $_ => 1 } @KEYS };
-    my $target  = { map { $_ => 1 } reverse keys %$compare };
+    my $target  = { map { $_ => 1 } reverse @KEYS };
     is ($v->validate($schema, [$compare, $target]), 0, 'validated as uniqueItems');
 };
 

--- a/t/issues/00041_canonical_xs.t
+++ b/t/issues/00041_canonical_xs.t
@@ -3,8 +3,8 @@ BEGIN { $ENV{PERL_JSON_BACKEND} = 'JSON::XS' }
 use strict;
 use warnings;
 use Test::More;
-use JSV::Validator;
 use Test::Requires qw(JSON::XS);
+use JSV::Validator;
 use JSON qw//;
 
 my @KEYS   = 'a'..'e';

--- a/t/issues/00041_canonical_xs.t
+++ b/t/issues/00041_canonical_xs.t
@@ -15,9 +15,6 @@ my $schema = {
 };
 
 subtest 'check cannonical on XS' => sub {
-    my $is_xs = JSON->is_xs;
-    ok $is_xs, 'backend is xs';
-
     my $compare = { map { $_ => 1 } @KEYS };
     my $target  = { map { $_ => 1 } reverse @KEYS };
     is ($v->validate($schema, [$compare, $target]), 0, 'validated as uniqueItems');

--- a/t/issues/00041_canonical_xs.t
+++ b/t/issues/00041_canonical_xs.t
@@ -1,0 +1,28 @@
+BEGIN { $ENV{PERL_JSON_BACKEND} = 'JSON::XS' }
+
+use strict;
+use warnings;
+use Test::More;
+use JSV::Validator;
+use Test::Requires qw(JSON::XS);
+use JSON qw//;
+
+my @KEYS   = 'a'..'e';
+my $v      = JSV::Validator->new(environment => 'draft4');
+my $schema = {
+    type => 'array',
+    uniqueItems => 1
+};
+
+subtest 'check cannonical on XS' => sub {
+    my $is_xs = JSON->is_xs;
+    ok $is_xs, 'backend is xs';
+
+    my $compare = { map { $_ => 1 } @KEYS };
+    my $target  = { map { $_ => 1 } reverse keys %$compare };
+    is ($v->validate($schema, [$compare, $target]), 0, 'validated as uniqueItems');
+};
+
+done_testing;
+
+1;


### PR DESCRIPTION
@zigorou 

`uniqueItems` において、 `[{"foo": 1, "bar": 2}, {"foo": 1, "bar": 2}]` など複数 key のある hash が
（Perl 内部で順序が保持されないために）別の json string として判定されてしまう問題を解消しました。