### PR TITLE
stop using Data::Walk

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,7 +4,6 @@ requires 'B';
 requires 'Carp';
 requires 'Class::Accessor::Lite';
 requires 'Clone';
-requires 'Data::Walk';
 requires 'Data::Validate::Domain';
 requires 'Data::Validate::IP';
 requires 'Data::Validate::URI';


### PR DESCRIPTION
`Data::Walk` overwrites `$_` global variable without any rewind, and it occasionally causes unexpected behavior (I met very hard bug due to that)
In my humble opinion `Data::Walk` is poor-quality, and the traversal logic is simple enough to write in scratch.